### PR TITLE
Implement custom backdrop widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.5
+
+* Added backdrop field to set custom background
+
 ## 1.3.4
 
 * Hot reload + state update support added.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ An advanced drawer widget, that can be fully customized with size, text, color, 
 |`drawer`|Drawer widget|*Widget*|required|
 |`controller`|Widget controller|*AdvancedDrawerController*| |
 |`backdropColor`|Backdrop color|*Color*| |
+|`backdrop`|Backdrop widget for custom background|*Widget*| |
 |`openRatio`|Opening ratio|*double*|0.75|
 |`openScale`|Opening child scale factor|*double*|0.85|
 |`animationDuration`|Animation duration|*Duration*|300ms|

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -25,7 +25,17 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     return AdvancedDrawer(
-      backdropColor: Colors.blueGrey,
+      backdrop: Container(
+        width: double.infinity,
+        height: double.infinity,
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [Colors.blueGrey, Colors.blueGrey.withOpacity(0.2)],
+          ),
+        ),
+      ),
       controller: _advancedDrawerController,
       animationCurve: Curves.easeInOut,
       animationDuration: const Duration(milliseconds: 300),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.4"
+    version: "1.3.5"
   js:
     dependency: transitive
     description:

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -8,6 +8,7 @@ class AdvancedDrawer extends StatefulWidget {
     required this.drawer,
     this.controller,
     this.backdropColor,
+    this.backdrop,
     this.openRatio = 0.75,
     this.openScale = 0.85,
     this.animationDuration = const Duration(milliseconds: 250),
@@ -30,6 +31,9 @@ class AdvancedDrawer extends StatefulWidget {
 
   /// Backdrop color.
   final Color? backdropColor;
+
+  /// Backdrop widget for custom background.
+  final Widget? backdrop;
 
   /// Opening ratio.
   final double openRatio;
@@ -111,6 +115,7 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
           color: Colors.transparent,
           child: Stack(
             children: [
+              if (widget.backdrop != null) widget.backdrop!,
               Align(
                 alignment: widget.rtlOpening
                     ? Alignment.centerRight

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_advanced_drawer
 description: An advanced drawer widget, that can be fully customized with size, text, color, radius of corners.
-version: 1.3.4
+version: 1.3.5
 homepage: https://github.com/alex-melnyk/flutter_advanced_drawer
 repository: https://github.com/alex-melnyk/flutter_advanced_drawer
 issue_tracker: https://github.com/alex-melnyk/flutter_advanced_drawer/issues


### PR DESCRIPTION
Hello @alex-melnyk 👋
I want to set a custom background but I don't found any filed for this.

Currently custom background can be set by **backdrop** filed.
Example of custom gradient at background:

```dart
backdrop: Container(
        width: double.infinity,
        height: double.infinity,
        decoration: BoxDecoration(
          gradient: LinearGradient(
            begin: Alignment.topLeft,
            end: Alignment.bottomRight,
            colors: [Colors.blueGrey, Colors.blueGrey.withOpacity(0.2)],
          ),
        ),
      ),
```
![telegram-cloud-photo-size-2-5359447281180461310-y](https://user-images.githubusercontent.com/40857927/235193030-360a9ed6-dc2f-4edd-bdf5-9edb8e8aa1e6.jpg)
