### PR TITLE
Add context and mounted check to _handleControllerChanged

### DIFF
--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -246,10 +246,14 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
   }
 
   void _handleControllerChanged() {
+  // Check if the widget is still mounted
+  if (context.mounted) {
+    // If the value of _controller is visible, forward the animation; otherwise, reverse it
     _controller.value.visible
         ? _animationController.forward()
         : _animationController.reverse();
   }
+}
 
   void _handleDragStart(DragStartDetails details) {
     _captured = true;


### PR DESCRIPTION
This commit addresses a potential issue in the _handleControllerChanged function by adding a check for widget mounted status. The modification ensures that the animation is only triggered when the widget is still part of the widget tree, preventing errors that may arise when attempting to manipulate the animation on an unmounted widget.