### PR TITLE
Fix for widget unmounted error

### DIFF
--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -249,13 +249,9 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
   }
 
   void _handleControllerChanged() {
-    // Check if the widget is still mounted
-    if (context.mounted) {
-      // If the value of _controller is visible, forward the animation; otherwise, reverse it
-      _controller.value.visible
-          ? _animationController.forward()
-          : _animationController.reverse();
-    }
+    // If widget is not mounted do nothing
+    if (!mounted) return;
+    _controller.value.visible ? _animationController.forward() : _animationController.reverse();
   }
 
   void _handleDragStart(DragStartDetails details) {

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -251,6 +251,7 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
   void _handleControllerChanged() {
     // If widget is not mounted do nothing
     if (!mounted) return;
+    // If the value of _controller is visible, forward the animation; otherwise, reverse it
     _controller.value.visible ? _animationController.forward() : _animationController.reverse();
   }
 


### PR DESCRIPTION
Changed the widget mount check from the BuildContext level to the framework level, this should make it better in rare scenarios where BuildContext is no longer valid