### PR TITLE
Support custom initial drawer scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ An advanced drawer widget, that can be fully customized with size, text, color, 
 |`animateChildDecoration`|Indicates that [childDecoration] might be animated or not.|*bool*|true|
 |`rtlOpening`|Opening from Right-to-left.|*bool*|false|
 |`disabledGestures`|Disable gestures.|*bool*|false|
+|`initialDrawerScale`|How large the drawer segment should scale from.|*double*|0.75|
 
 ## Preview
 | Preview Tap | Preview Gesture |

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -11,6 +11,7 @@ class AdvancedDrawer extends StatefulWidget {
     this.backdrop,
     this.openRatio = 0.75,
     this.openScale = 0.85,
+    this.initialDrawerScale = 0.75,
     this.animationDuration = const Duration(milliseconds: 250),
     this.animationCurve,
     this.childDecoration,
@@ -40,6 +41,10 @@ class AdvancedDrawer extends StatefulWidget {
 
   /// Opening ratio.
   final double openScale;
+
+  /// How large the drawer segment should scale from.
+  /// Set to 1 to disable drawer segment scale effect.
+  final double initialDrawerScale;
 
   /// Animation duration.
   final Duration animationDuration;
@@ -228,7 +233,7 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
           );
 
     _drawerScaleAnimation = Tween<double>(
-      begin: 0.75,
+      begin: widget.initialDrawerScale,
       end: 1.0,
     ).animate(parentAnimation);
 


### PR DESCRIPTION
Allows customizing how much the drawer segment scales. More importantly, enables disabling this scale effect completely if desired to have more simple push drawer.

The default is 0.75 (what it was before) to make this a non-breaking change.

Relates to #52

Preview:

https://github.com/user-attachments/assets/23bd927a-1131-40ea-92d5-a86f3c9b17db

