### PR TITLE
Disable ripple on content inkwell

### DIFF
--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -158,6 +158,7 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
                                 color: Colors.transparent,
                                 child: InkWell(
                                   onTap: _controller.hideDrawer,
+                                  splashColor: Colors.transparent,
                                   highlightColor: Colors.transparent,
                                   child: Container(),
                                 ),


### PR DESCRIPTION
Currently, there is a default ripple effect caused by the `InkWell` around the content when open. This looks a bit odd having the content behave as a button:

https://github.com/user-attachments/assets/f0604e7e-d49a-4f12-829d-fce8884dc8e3

Making this ripple transparent effectively disables it:

https://github.com/user-attachments/assets/985bdd06-faf7-4fb5-a81e-75fa8ebae053

If you would prefer to have this on by default I can update this PR to add `splashColor` as an option to `AdvancedDrawer`
