### PR TITLE
[a11y] Improve the accesbility of the AdvancedDrawer widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.5.0
+
+* Added `drawerCloseSemanticLabel` parameter to set a semantic label for the tappable area that closes the drawer.
+* Integrated [`Semantics`](https://api.flutter.dev/flutter/widgets/Semantics-class.html) widgets to provide better screen reader support.
+* Integrated [`ExcludeFocus`](https://api.flutter.dev/flutter/widgets/ExcludeFocus-class.html) and [`ExcludeSemantics`](https://api.flutter.dev/flutter/widgets/ExcludeSemantics-class.html) to widgets to dynamically control focus and semantics based on drawer visibility.
+* Refactored Inkwell hiding to use `Visibility`
+
 ## 1.4.0
 
 * Added "initialDrawerScale" parameter to set the initial scale of the drawer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.5.0
 
 * Added `drawerCloseSemanticLabel` parameter to set a semantic label for the tappable area that closes the drawer.
-* Integrated [`Semantics`](https://api.flutter.dev/flutter/widgets/Semantics-class.html) widgets to provide better screen reader support.
+* Integrated [`Semantics`](https://api.flutter.dev/flutter/widgets/Semantics-class.html) widgets to provide better screen reader support for the drawer and example app.
 * Integrated [`ExcludeFocus`](https://api.flutter.dev/flutter/widgets/ExcludeFocus-class.html) and [`ExcludeSemantics`](https://api.flutter.dev/flutter/widgets/ExcludeSemantics-class.html) to widgets to dynamically control focus and semantics based on drawer visibility.
 * Refactored Inkwell hiding to use `Visibility`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 
 ## 1.4.0
 
-* Added "initialDrawerScale" parameter to set the initial scale of the drawer.
-* Added "drawerSlideRatio" parameter to set the slide ratio of the drawer.
+* Added `initialDrawerScale` parameter to set the initial scale of the drawer.
+* Added `drawerSlideRatio` parameter to set the slide ratio of the drawer.
 
 ## 1.3.7
 
@@ -20,7 +20,7 @@
 
 ## 1.3.5
 
-* Added backdrop field to set custom background
+* Added `backdrop` field to set custom background
 
 ## 1.3.4
 
@@ -54,7 +54,7 @@
 
 ## 1.2.3
 
-* "disabledGestures" option added to disable gestures.
+* `disabledGestures` option added to disable gestures.
 
 ## 1.2.2
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,36 @@
 # flutter_advanced_drawer
+
 An advanced drawer widget, that can be fully customized with size, text, color, radius of corners.
 
 ## Advanced Drawer States
-| Drawer Open State | Drawer Closed State |
-|:-:|:-:|
+
+|                  Drawer Open State                  |                  Drawer Closed State                  |
+| :-------------------------------------------------: | :---------------------------------------------------: |
 | ![Advanced Drawer Open State](./PREVIEW_OPENED.png) | ![Advanced Drawer Closed State](./PREVIEW_CLOSED.png) |
 
 ## AdvancedDrawer Parameters
-|Parameter|Description|Type|Default|
-|:--------|:----------|:---|:------|
-|`child`|Screen widget|*Widget*|required|
-|`drawer`|Drawer widget|*Widget*|required|
-|`controller`|Widget controller|*AdvancedDrawerController*| |
-|`backdropColor`|Backdrop color|*Color*| |
-|`backdrop`|Backdrop widget for custom background|*Widget*| |
-|`openRatio`|Opening ratio|*double*|0.75|
-|`openScale`|Opening child scale factor|*double*|0.85|
-|`animationDuration`|Animation duration|*Duration*|300ms|
-|`animationCurve`|Animation curve|*Curve*|Curves.easeInOut|
-|`childDecoration`|Child container decoration|*BoxDecoration*|Shadow, BorderRadius|
-|`animateChildDecoration`|Indicates that [childDecoration] might be animated or not.|*bool*|true|
-|`rtlOpening`|Opening from Right-to-left.|*bool*|false|
-|`disabledGestures`|Disable gestures.|*bool*|false|
-|`initialDrawerScale`|How large the drawer segment should scale from.|*double*|0.75|
-|`drawerSlideRatio`|How far the drawer segment should slide with the content.|*double*|0|
+
+| Parameter                  | Description                                                | Type                       | Default              |
+| :------------------------- | :--------------------------------------------------------- | :------------------------- | :------------------- |
+| `child`                    | Screen widget                                              | _Widget_                   | required             |
+| `drawer`                   | Drawer widget                                              | _Widget_                   | required             |
+| `controller`               | Widget controller                                          | _AdvancedDrawerController_ |                      |
+| `backdropColor`            | Backdrop color                                             | _Color_                    |                      |
+| `backdrop`                 | Backdrop widget for custom background                      | _Widget_                   |                      |
+| `openRatio`                | Opening ratio                                              | _double_                   | 0.75                 |
+| `openScale`                | Opening child scale factor                                 | _double_                   | 0.85                 |
+| `animationDuration`        | Animation duration                                         | _Duration_                 | 300ms                |
+| `animationCurve`           | Animation curve                                            | _Curve_                    | Curves.easeInOut     |
+| `childDecoration`          | Child container decoration                                 | _BoxDecoration_            | Shadow, BorderRadius |
+| `animateChildDecoration`   | Indicates that [childDecoration] might be animated or not. | _bool_                     | true                 |
+| `rtlOpening`               | Opening from Right-to-left.                                | _bool_                     | false                |
+| `disabledGestures`         | Disable gestures.                                          | _bool_                     | false                |
+| `initialDrawerScale`       | How large the drawer segment should scale from.            | _double_                   | 0.75                 |
+| `drawerSlideRatio`         | How far the drawer segment should slide with the content.  | _double_                   | 0                    |
+| `drawerCloseSemanticLabel` | Semantic label for the close drawer button.                | _String_                   | 'Close drawer'       |
 
 ## Preview
-| Preview Tap | Preview Gesture |
-|:-:|:-:|
+
+|                     Preview Tap                     |                  Preview Gesture                   |
+| :-------------------------------------------------: | :------------------------------------------------: |
 | ![Advanced Drawer Tap Animation](./PREVIEW_TAP.gif) | ![Advanced Drawer Gestures](./PREVIEW_GESTURE.gif) |

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -64,9 +64,13 @@ class _HomeScreenState extends State<HomeScreen> {
               builder: (_, value, __) {
                 return AnimatedSwitcher(
                   duration: Duration(milliseconds: 250),
-                  child: Icon(
-                    value.visible ? Icons.clear : Icons.menu,
-                    key: ValueKey<bool>(value.visible),
+                  child: Semantics(
+                    label: 'Menu',
+                    onTapHint: 'expand drawer',
+                    child: Icon(
+                      value.visible ? Icons.clear : Icons.menu,
+                      key: ValueKey<bool>(value.visible),
+                    ),
                   ),
                 );
               },

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -166,41 +166,31 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
                       ? Alignment.centerRight
                       : Alignment.centerLeft,
                   scale: _childScaleAnimation,
-                  child: Builder(
-                    builder: (_) {
+                  child: ValueListenableBuilder<AdvancedDrawerValue>(
+                    valueListenable: _controller,
+                    builder: (_, value, __) {
                       final childStack = Stack(
                         children: [
-                          ValueListenableBuilder<AdvancedDrawerValue>(
-                            valueListenable: _controller,
-                            builder: (_, value, __) {
-                              return ExcludeSemantics(
-                                  excluding: value.visible,
-                                  child: RepaintBoundary(child: widget.child));
-                            },
-                          ),
-                          ValueListenableBuilder<AdvancedDrawerValue>(
-                            valueListenable: _controller,
-                            builder: (_, value, __) {
-                              if (!value.visible) {
-                                return const SizedBox();
-                              }
-
-                              return Material(
-                                color: Colors.transparent,
-                                child: Semantics(
-                                  label: widget.drawerCloseSemanticLabel ??
-                                      'Close drawer',
-                                  button: true,
-                                  child: InkWell(
-                                    onTap: _controller.hideDrawer,
-                                    splashColor: Colors.transparent,
-                                    highlightColor: Colors.transparent,
-                                    child: Container(),
-                                  ),
+                          ExcludeSemantics(
+                              excluding: value.visible,
+                              child: RepaintBoundary(child: widget.child)),
+                          Visibility(
+                            visible: value.visible,
+                            child: Material(
+                              color: Colors.transparent,
+                              child: Semantics(
+                                label: widget.drawerCloseSemanticLabel ??
+                                    'Close drawer',
+                                button: true,
+                                child: InkWell(
+                                  onTap: _controller.hideDrawer,
+                                  splashColor: Colors.transparent,
+                                  highlightColor: Colors.transparent,
+                                  child: Container(),
                                 ),
-                              );
-                            },
-                          ),
+                              ),
+                            ),
+                          )
                         ],
                       );
 

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -151,7 +151,19 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
                           ? Alignment.centerLeft
                           : Alignment.centerRight,
                       child: RepaintBoundary(
-                        child: widget.drawer,
+                        child: ValueListenableBuilder<AdvancedDrawerValue>(
+                            valueListenable: _controller,
+                            builder: (_, value, __) {
+                              return ExcludeFocus(
+                                excluding: !value.visible,
+                                child: Semantics(
+                                  excludeSemantics: !value.visible,
+                                  container: true,
+                                  explicitChildNodes: true,
+                                  child: widget.drawer,
+                                ),
+                              );
+                            }),
                       ),
                     ),
                   ),
@@ -171,9 +183,12 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
                     builder: (_, value, __) {
                       final childStack = Stack(
                         children: [
-                          ExcludeSemantics(
-                              excluding: value.visible,
-                              child: RepaintBoundary(child: widget.child)),
+                          ExcludeFocus(
+                            excluding: value.visible,
+                            child: ExcludeSemantics(
+                                excluding: value.visible,
+                                child: RepaintBoundary(child: widget.child)),
+                          ),
                           Visibility(
                             visible: value.visible,
                             child: Material(
@@ -182,6 +197,7 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
                                 label: widget.drawerCloseSemanticLabel ??
                                     'Close drawer',
                                 button: true,
+                                container: true,
                                 child: InkWell(
                                   onTap: _controller.hideDrawer,
                                   splashColor: Colors.transparent,

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -20,7 +20,7 @@ class AdvancedDrawer extends StatefulWidget {
     this.rtlOpening = false,
     this.disabledGestures = false,
     this.animationController,
-    this.drawerCloseSemanticLabel,
+    this.drawerCloseSemanticLabel = 'Close drawer',
   }) : super(key: key);
 
   /// Child widget. (Usually widget that represent a screen)
@@ -206,8 +206,7 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
                             child: Material(
                               color: Colors.transparent,
                               child: Semantics(
-                                label: widget.drawerCloseSemanticLabel ??
-                                    'Close drawer',
+                                label: widget.drawerCloseSemanticLabel,
                                 button: true,
                                 container: true,
                                 child: InkWell(

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -20,6 +20,7 @@ class AdvancedDrawer extends StatefulWidget {
     this.rtlOpening = false,
     this.disabledGestures = false,
     this.animationController,
+    this.drawerCloseSemanticLabel,
   }) : super(key: key);
 
   /// Child widget. (Usually widget that represent a screen)
@@ -73,6 +74,14 @@ class AdvancedDrawer extends StatefulWidget {
 
   /// Controller that controls widget animation.
   final AnimationController? animationController;
+
+  /// Provides a textual description of the close drawer action.
+  ///
+  /// This is used by accessibility frameworks to provide context
+  /// for screen readers of what the close drawer action will do.
+  ///
+  /// if null, it will default to `'Close drawer'`
+  final String? drawerCloseSemanticLabel;
 
   @override
   _AdvancedDrawerState createState() => _AdvancedDrawerState();
@@ -161,7 +170,14 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
                     builder: (_) {
                       final childStack = Stack(
                         children: [
-                          RepaintBoundary(child: widget.child),
+                          ValueListenableBuilder<AdvancedDrawerValue>(
+                            valueListenable: _controller,
+                            builder: (_, value, __) {
+                              return ExcludeSemantics(
+                                  excluding: value.visible,
+                                  child: RepaintBoundary(child: widget.child));
+                            },
+                          ),
                           ValueListenableBuilder<AdvancedDrawerValue>(
                             valueListenable: _controller,
                             builder: (_, value, __) {
@@ -171,11 +187,16 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
 
                               return Material(
                                 color: Colors.transparent,
-                                child: InkWell(
-                                  onTap: _controller.hideDrawer,
-                                  splashColor: Colors.transparent,
-                                  highlightColor: Colors.transparent,
-                                  child: Container(),
+                                child: Semantics(
+                                  label: widget.drawerCloseSemanticLabel ??
+                                      'Close drawer',
+                                  button: true,
+                                  child: InkWell(
+                                    onTap: _controller.hideDrawer,
+                                    splashColor: Colors.transparent,
+                                    highlightColor: Colors.transparent,
+                                    child: Container(),
+                                  ),
                                 ),
                               );
                             },

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -273,7 +273,9 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
     // If widget is not mounted do nothing
     if (!mounted) return;
     // If the value of _controller is visible, forward the animation; otherwise, reverse it
-    _controller.value.visible ? _animationController.forward() : _animationController.reverse();
+    _controller.value.visible
+        ? _animationController.forward()
+        : _animationController.reverse();
   }
 
   void _handleDragStart(DragStartDetails details) {

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -136,39 +136,45 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
           color: Colors.transparent,
           child: Stack(
             children: [
-              if (widget.backdrop != null) widget.backdrop!,
-              Align(
-                alignment: widget.rtlOpening
-                    ? Alignment.centerRight
-                    : Alignment.centerLeft,
-                child: SlideTransition(
-                  position: _drawerSlideAnimation,
-                  child: FractionallySizedBox(
-                    widthFactor: widget.openRatio,
-                    child: ScaleTransition(
-                      scale: _drawerScaleAnimation,
-                      alignment: widget.rtlOpening
-                          ? Alignment.centerLeft
-                          : Alignment.centerRight,
-                      child: RepaintBoundary(
-                        child: ValueListenableBuilder<AdvancedDrawerValue>(
-                            valueListenable: _controller,
-                            builder: (_, value, __) {
-                              return ExcludeFocus(
-                                excluding: !value.visible,
-                                child: Semantics(
-                                  excludeSemantics: !value.visible,
-                                  container: true,
-                                  explicitChildNodes: true,
-                                  child: widget.drawer,
+              ValueListenableBuilder<AdvancedDrawerValue>(
+                  valueListenable: _controller,
+                  builder: (_, value, __) {
+                    return ExcludeFocus(
+                      excluding: !value.visible,
+                      child: ExcludeSemantics(
+                        excluding: !value.visible,
+                        child: Stack(
+                          children: [
+                            if (widget.backdrop != null) widget.backdrop!,
+                            Align(
+                              alignment: widget.rtlOpening
+                                  ? Alignment.centerRight
+                                  : Alignment.centerLeft,
+                              child: SlideTransition(
+                                position: _drawerSlideAnimation,
+                                child: FractionallySizedBox(
+                                  widthFactor: widget.openRatio,
+                                  child: ScaleTransition(
+                                    scale: _drawerScaleAnimation,
+                                    alignment: widget.rtlOpening
+                                        ? Alignment.centerLeft
+                                        : Alignment.centerRight,
+                                    child: RepaintBoundary(
+                                      child: Semantics(
+                                        container: true,
+                                        explicitChildNodes: true,
+                                        child: widget.drawer,
+                                      ),
+                                    ),
+                                  ),
                                 ),
-                              );
-                            }),
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
-                    ),
-                  ),
-                ),
-              ),
+                    );
+                  }),
               SlideTransition(
                 position: _childSlideAnimation,
                 textDirection:
@@ -186,8 +192,11 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
                           ExcludeFocus(
                             excluding: value.visible,
                             child: ExcludeSemantics(
-                                excluding: value.visible,
-                                child: RepaintBoundary(child: widget.child)),
+                              excluding: value.visible,
+                              child: RepaintBoundary(
+                                child: widget.child,
+                              ),
+                            ),
                           ),
                           Visibility(
                             visible: value.visible,

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -137,44 +137,46 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
           child: Stack(
             children: [
               ValueListenableBuilder<AdvancedDrawerValue>(
-                  valueListenable: _controller,
-                  builder: (_, value, __) {
-                    return ExcludeFocus(
+                valueListenable: _controller,
+                builder: (_, value, child) {
+                  return ExcludeFocus(
+                    excluding: !value.visible,
+                    child: ExcludeSemantics(
                       excluding: !value.visible,
-                      child: ExcludeSemantics(
-                        excluding: !value.visible,
-                        child: Stack(
-                          children: [
-                            if (widget.backdrop != null) widget.backdrop!,
-                            Align(
-                              alignment: widget.rtlOpening
-                                  ? Alignment.centerRight
-                                  : Alignment.centerLeft,
-                              child: SlideTransition(
-                                position: _drawerSlideAnimation,
-                                child: FractionallySizedBox(
-                                  widthFactor: widget.openRatio,
-                                  child: ScaleTransition(
-                                    scale: _drawerScaleAnimation,
-                                    alignment: widget.rtlOpening
-                                        ? Alignment.centerLeft
-                                        : Alignment.centerRight,
-                                    child: RepaintBoundary(
-                                      child: Semantics(
-                                        container: true,
-                                        explicitChildNodes: true,
-                                        child: widget.drawer,
-                                      ),
-                                    ),
-                                  ),
-                                ),
+                      child: child,
+                    ),
+                  );
+                },
+                child: Stack(
+                  children: [
+                    if (widget.backdrop != null) widget.backdrop!,
+                    Align(
+                      alignment: widget.rtlOpening
+                          ? Alignment.centerRight
+                          : Alignment.centerLeft,
+                      child: SlideTransition(
+                        position: _drawerSlideAnimation,
+                        child: FractionallySizedBox(
+                          widthFactor: widget.openRatio,
+                          child: ScaleTransition(
+                            scale: _drawerScaleAnimation,
+                            alignment: widget.rtlOpening
+                                ? Alignment.centerLeft
+                                : Alignment.centerRight,
+                            child: RepaintBoundary(
+                              child: Semantics(
+                                container: true,
+                                explicitChildNodes: true,
+                                child: widget.drawer,
                               ),
                             ),
-                          ],
+                          ),
                         ),
                       ),
-                    );
-                  }),
+                    ),
+                  ],
+                ),
+              ),
               SlideTransition(
                 position: _childSlideAnimation,
                 textDirection:
@@ -186,7 +188,8 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
                   scale: _childScaleAnimation,
                   child: ValueListenableBuilder<AdvancedDrawerValue>(
                     valueListenable: _controller,
-                    builder: (_, value, __) {
+                    child: widget.child,
+                    builder: (_, value, child) {
                       final childStack = Stack(
                         children: [
                           ExcludeFocus(
@@ -194,7 +197,7 @@ class _AdvancedDrawerState extends State<AdvancedDrawer>
                             child: ExcludeSemantics(
                               excluding: value.visible,
                               child: RepaintBoundary(
-                                child: widget.child,
+                                child: child,
                               ),
                             ),
                           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: flutter_advanced_drawer
 description: An advanced drawer widget, that can be fully customized with size, text, color, radius of corners.
-version: 1.4.0
+version: 1.5.0
 homepage: https://github.com/alex-melnyk/flutter_advanced_drawer
 repository: https://github.com/alex-melnyk/flutter_advanced_drawer
 issue_tracker: https://github.com/alex-melnyk/flutter_advanced_drawer/issues
 documentation: https://github.com/alex-melnyk/flutter_advanced_drawer/blob/master/README.md
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description of the Issue
Currently, the `AdvancedDrawer` widget has several accessibility issues that are difficult to resolve outside the package:

- Nav drawer items remain accessible via screen readers and physical keyboards when the drawer is closed
    - Failure of [WCAG 2.4.3: Focus Order](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html)
- Content behind an open drawer can still be interacted with using screen readers or keyboards
    - Failure of [WCAG 2.4.11: Focus Not Obscured (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html)
- The drawer close button lacks a semantic label, making its purpose unclear for screen reader users
    - Failure of [WCAG 4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)

Reference: [Flutter Accessibility Documentation](https://docs.flutter.dev/ui/accessibility-and-internationalization/accessibility)

## Changes
- Added `drawerCloseSemanticLabel` field to provide a semantic label for the close button
- Implemented `ExcludeFocus` and `ExcludeSemantics` widgets in appropriate places
- Made minor optimizations, such as using `Visibility` widget where possible

## Visual Demonstration

### Screen Reader Navigation
| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/64177f09-dd3a-441f-899b-fcb5dc3da0d4" /> | <video src="https://github.com/user-attachments/assets/ef7cc1ad-be9b-4ea3-b8fd-f47ed35e6b26" /> |

### External Bluetooth Keyboard Navigation
> [!NOTE]
> The [focus_debugger](https://pub.dev/packages/focus_debugger) package was used to visualize the focused element.
> 
> It should be noted debugger has a issue where the box occupies the entire screen when focus is lost. In the video, this just indicates that the focus node element no longer exists in the focus tree (Due to the addition of `ExcludeFocus`)

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/7dafcefa-f09c-4887-b695-0ef95a10b507" /> | <video src="https://github.com/user-attachments/assets/c5748c45-2c79-4b4f-aca8-87e8c0e6293f" /> |